### PR TITLE
Update to check Language association to the current store

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -160,7 +160,7 @@ if (defined('_PS_ADMIN_DIR_'))
 /* if the language stored in the cookie is not available language, use default language */
 if (isset($cookie->id_lang) && $cookie->id_lang)
 	$language = new Language($cookie->id_lang);
-if (!isset($language) || !Validate::isLoadedObject($language))
+if (!isset($language) || !Validate::isLoadedObject($language) || !$language->isAssociatedToShop())
 	$language = new Language(Configuration::get('PS_LANG_DEFAULT'));
 $context->language = $language;
 


### PR DESCRIPTION
This change force PrestaShop to check if the id_lang from the Prestashop cookie is available in the current store, if not available and associated then the default language is selected.